### PR TITLE
Testcontainers labels

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,13 +31,18 @@ let package = Package(
             dependencies: [
                 "DockerClientSwift",
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
             ],
             path: "Sources/Testcontainers"
         ),
         .testTarget(
             name: "TestcontainersTests",
-            dependencies: ["Testcontainers"],
+            dependencies: [
+                "Testcontainers",
+                "DockerClientSwift",
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+            ],
             path: "Tests"
         ),
     ]

--- a/Sources/DockerClientSwift/APIs/DockerClient.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient.swift
@@ -8,6 +8,7 @@ import NIOHTTP1
 public class DockerClient {
     private let daemonSocket: String
     private let client: HTTPClient
+    private let customHeaders: HTTPHeaders
     let logger: Logger
 
     /// Initialize the `DockerClient`.
@@ -15,14 +16,17 @@ public class DockerClient {
     ///   - daemonSocket: The socket path where the Docker API is listening on. Default is `/var/run/docker.sock`.
     ///   - client: `HTTPClient` instance that is used to execute the requests.
     ///   - logger: `Logger` for the `DockerClient`. Default is `.init(label: "docker-client")`.
+    ///   - customHeaders: Additional HTTP headers to include with every Docker API request.
     public init(
         daemonSocket: String = "/var/run/docker.sock",
         client: HTTPClient = HTTPClient(eventLoopGroupProvider: .singleton),
-        logger: Logger = .init(label: "docker-client"))
+        logger: Logger = .init(label: "docker-client"),
+        customHeaders: HTTPHeaders = HTTPHeaders())
     {
         self.daemonSocket = daemonSocket
         self.client = client
         self.logger = logger
+        self.customHeaders = customHeaders
     }
 
     /// Shuts down the client. The client needs to be shutdown otherwise it can crash on exit.
@@ -44,7 +48,7 @@ public class DockerClient {
         let response = try await client.execute(
             endpoint.method, socketPath: daemonSocket, urlPath: "/v1.44/\(endpoint.path)",
             body: bodyData, logger: logger,
-            headers: HTTPHeaders([("Content-Type", "application/json"), ("Host", "localhost")])
+            headers: buildHeaders()
         )
         response.logResponseBody(logger)
         return try response.decode(as: T.Response.self)
@@ -59,9 +63,22 @@ public class DockerClient {
         let response = try await client.execute(
             endpoint.method, socketPath: daemonSocket, urlPath: "/v1.44/\(endpoint.path)",
             body: bodyData, logger: logger,
-            headers: HTTPHeaders([("Content-Type", "application/json"), ("Host", "localhost")])
+            headers: buildHeaders()
         )
         response.logResponseBody(logger)
         return try response.mapString(map: endpoint.map(data:))
+    }
+
+    /// Builds the HTTP headers for a Docker API request by combining the
+    /// mandatory base headers with any caller-supplied custom headers.
+    func buildHeaders() -> HTTPHeaders {
+        var headers = HTTPHeaders([
+            ("Content-Type", "application/json"),
+            ("Host", "localhost"),
+        ])
+        for (name, value) in customHeaders {
+            headers.replaceOrAdd(name: name, value: value)
+        }
+        return headers
     }
 }

--- a/Sources/Testcontainers/Container.swift
+++ b/Sources/Testcontainers/Container.swift
@@ -322,12 +322,14 @@ public class ContainerBuilder {
     /// Builds a container instance without creating it in Docker.
     /// - Returns: A container instance.
     public func build() -> Container {
-        DockerContainerImpl(
+        var mergedLabels = labels
+        TestcontainersLabels.addDefaultLabels(to: &mergedLabels)
+        return DockerContainerImpl(
             id: UUID().uuidString,
             image: image,
             client: client,
             name: name,
-            labels: labels
+            labels: mergedLabels
         )
     }
 
@@ -340,10 +342,14 @@ public class ContainerBuilder {
         // Pull the image first
         try await client.pullImage(image: image)
 
+        // Merge standard Testcontainers labels with user-defined labels
+        var mergedLabels = labels
+        TestcontainersLabels.addDefaultLabels(to: &mergedLabels)
+
         // Create Container configuration
         var request = CreateContainerRequest(image: image)
         request.hostname = name
-        request.labels = labels
+        request.labels = mergedLabels
 
         // Set environment variables
         if !environment.isEmpty {
@@ -388,7 +394,7 @@ public class ContainerBuilder {
             image: image,
             client: client,
             name: name,
-            labels: labels
+            labels: mergedLabels
         )
 
         // Connect to network if specified

--- a/Sources/Testcontainers/DockerClient.swift
+++ b/Sources/Testcontainers/DockerClient.swift
@@ -26,7 +26,7 @@ public enum DockerClientError: Error {
 /// A Docker client wrapper for Testcontainers, built on top of DockerClientSwift.
 /// Provides container lifecycle management, image operations, and network support.
 public class TestcontainersDockerClient: @unchecked Sendable {
-    private struct SharedState: Sendable {
+    private enum SharedState {
         static let lock = NSLock()
         // Use a mutable class wrapper stored inside the lock-protected section
     }

--- a/Sources/Testcontainers/DockerClient.swift
+++ b/Sources/Testcontainers/DockerClient.swift
@@ -331,11 +331,15 @@ public class TestcontainersDockerClient: @unchecked Sendable {
     /// - Parameters:
     ///   - name: The network name.
     ///   - driver: The network driver, defaults to "bridge".
+    ///   - labels: Labels to attach to the network.
     /// - Returns: The ID of the created network.
     /// - Throws: An error if network creation fails.
-    public func createNetwork(name: String, driver: String = "bridge") async throws -> String {
+    public func createNetwork(name: String, driver: String = "bridge",
+                              labels: [String: String] = [:]) async throws
+        -> String
+    {
         // DockerClientSwift doesn't have network support, fall back to raw API
-        try await createNetworkViaRawAPI(name: name, driver: driver)
+        try await createNetworkViaRawAPI(name: name, driver: driver, labels: labels)
     }
 
     /// Connect a container to a network
@@ -420,8 +424,11 @@ public class TestcontainersDockerClient: @unchecked Sendable {
     }
 
     /// Raw API call for network create
-    private func createNetworkViaRawAPI(name: String, driver: String) async throws -> String {
-        let endpoint = RawCreateNetworkEndpoint(name: name, driver: driver)
+    private func createNetworkViaRawAPI(name: String, driver: String,
+                                        labels: [String: String] = [:]) async throws
+        -> String
+    {
+        let endpoint = RawCreateNetworkEndpoint(name: name, driver: driver, labels: labels)
         let response = try await client.run(endpoint)
         return response.Id
     }

--- a/Sources/Testcontainers/DockerClient.swift
+++ b/Sources/Testcontainers/DockerClient.swift
@@ -1,6 +1,7 @@
 import DockerClientSwift
 import Foundation
 import Logging
+import NIOHTTP1
 
 // MARK: - Error Types
 
@@ -46,7 +47,10 @@ public class TestcontainersDockerClient: @unchecked Sendable {
     ///   - socketPath: Path to Docker socket (auto-detected if nil)
     public init(socketPath: String? = nil) {
         let resolvedPath = socketPath ?? Self.detectSocketPath()
-        self.client = DockerClientSwift.DockerClient(daemonSocket: resolvedPath)
+        self.client = DockerClientSwift.DockerClient(
+            daemonSocket: resolvedPath,
+            customHeaders: Self.testcontainersHeaders()
+        )
         self.logger = Logger(label: "testcontainers-swift.docker-client")
     }
 
@@ -70,6 +74,21 @@ public class TestcontainersDockerClient: @unchecked Sendable {
     /// - Throws: An error if shutdown fails.
     public func shutdown() async throws {
         try await client.shutdown()
+    }
+
+    // MARK: - Testcontainers HTTP Headers
+
+    /// Builds the custom HTTP headers sent with every Docker API request.
+    ///
+    /// Follows the Testcontainers community convention used by the Java, .NET
+    /// and Go implementations:
+    /// - `x-tc-sid` — the process-level session ID
+    /// - `User-Agent` — identifies the library and version
+    static func testcontainersHeaders() -> HTTPHeaders {
+        HTTPHeaders([
+            ("x-tc-sid", TestcontainersLabels.sessionId),
+            ("User-Agent", "tc-swift/\(TestcontainersLabels.version)"),
+        ])
     }
 
     // MARK: - Socket Detection

--- a/Sources/Testcontainers/Labels.swift
+++ b/Sources/Testcontainers/Labels.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+// MARK: - Testcontainers Standard Labels
+
+/// Standard label keys used by all Testcontainers implementations to identify
+/// and manage resources created by the library.
+///
+/// These labels follow the Testcontainers community specification and are
+/// consistent across Java, .NET, Go, and Swift implementations.
+///
+/// ## Label Keys
+/// | Key | Description |
+/// |-----|-------------|
+/// | ``labelBase`` | Marks a resource as created by Testcontainers |
+/// | ``labelLang`` | Identifies the language of the Testcontainers library |
+/// | ``labelVersion`` | The version of the Testcontainers library |
+/// | ``labelSessionId`` | The unique session ID for the current process |
+///
+/// ## Usage
+/// Labels are automatically applied to containers and networks created through
+/// ``ContainerBuilder`` and ``NetworkBuilder``. To retrieve the default label
+/// set programmatically, use ``TestcontainersLabels/defaultLabels``.
+public enum TestcontainersLabels {
+
+    // MARK: - Label Keys
+
+    /// Base label key identifying a resource as created by Testcontainers.
+    ///
+    /// Value is always `"true"`.
+    public static let labelBase = "org.testcontainers"
+
+    /// Label key identifying the programming language of the Testcontainers library.
+    public static let labelLang = labelBase + ".lang"
+
+    /// Label key containing the version of the Testcontainers library.
+    public static let labelVersion = labelBase + ".version"
+
+    /// Label key containing the unique session ID for the current test process.
+    public static let labelSessionId = labelBase + ".sessionId"
+
+    // MARK: - Values
+
+    /// The language identifier for this Testcontainers implementation.
+    public static let lang = "swift"
+
+    /// The version of the testcontainers-swift library.
+    ///
+    /// Update this value when releasing a new version.
+    public static let version = "0.1.0"
+
+    /// A process-level session ID generated once and reused for the lifetime of the process.
+    ///
+    /// This unique identifier groups all containers and networks created during
+    /// a single test session, enabling ecosystem tooling (e.g. Testcontainers
+    /// Cloud, resource reaper) to manage resources correctly.
+    public static let sessionId: String = UUID().uuidString
+
+    // MARK: - Default Labels
+
+    /// Returns the standard set of labels that should be applied to all
+    /// Testcontainers-managed resources (containers and networks).
+    ///
+    /// - Returns: A dictionary containing the four standard Testcontainers labels.
+    public static var defaultLabels: [String: String] {
+        [
+            labelBase: "true",
+            labelLang: lang,
+            labelVersion: version,
+            labelSessionId: sessionId,
+        ]
+    }
+
+    /// Merges the standard Testcontainers labels into the given label dictionary.
+    ///
+    /// User-defined labels with the same keys are **not** overwritten; the
+    /// standard labels act as defaults.
+    ///
+    /// - Parameter labels: The mutable label dictionary to merge into.
+    public static func addDefaultLabels(to labels: inout [String: String]) {
+        for (key, value) in defaultLabels where labels[key] == nil {
+            labels[key] = value
+        }
+    }
+}

--- a/Sources/Testcontainers/Labels.swift
+++ b/Sources/Testcontainers/Labels.swift
@@ -21,7 +21,6 @@ import Foundation
 /// ``ContainerBuilder`` and ``NetworkBuilder``. To retrieve the default label
 /// set programmatically, use ``TestcontainersLabels/defaultLabels``.
 public enum TestcontainersLabels {
-
     // MARK: - Label Keys
 
     /// Base label key identifying a resource as created by Testcontainers.

--- a/Sources/Testcontainers/Labels.swift
+++ b/Sources/Testcontainers/Labels.swift
@@ -44,8 +44,10 @@ public enum TestcontainersLabels {
 
     /// The version of the testcontainers-swift library.
     ///
-    /// Update this value when releasing a new version.
-    public static let version = "0.1.0"
+    /// This is the single source of truth for the library version, referenced
+    /// by labels, HTTP headers, and User-Agent strings. Update this constant
+    /// when cutting a new release.
+    public static let version = PackageVersion.current
 
     /// A process-level session ID generated once and reused for the lifetime of the process.
     ///

--- a/Sources/Testcontainers/Labels.swift
+++ b/Sources/Testcontainers/Labels.swift
@@ -15,6 +15,9 @@ import Foundation
 /// | ``labelLang`` | Identifies the language of the Testcontainers library |
 /// | ``labelVersion`` | The version of the Testcontainers library |
 /// | ``labelSessionId`` | The unique session ID for the current process |
+/// | ``labelReaper`` | Identifies a resource-reaper (Ryuk) container |
+/// | ``labelRyuk`` | Identifies a Ryuk container (alias of ``labelReaper``) |
+/// | ``labelReap`` | Marks a resource for automatic cleanup by the reaper |
 ///
 /// ## Usage
 /// Labels are automatically applied to containers and networks created through
@@ -36,6 +39,26 @@ public enum TestcontainersLabels {
 
     /// Label key containing the unique session ID for the current test process.
     public static let labelSessionId = labelBase + ".sessionId"
+
+    /// Label key identifying a resource-reaper (Ryuk) container.
+    ///
+    /// Set to `"true"` on the reaper sidecar container itself. Reserved for
+    /// future use when the Swift implementation adds Ryuk support.
+    public static let labelReaper = labelBase + ".reaper"
+
+    /// Label key identifying a Ryuk container (alias of ``labelReaper``).
+    ///
+    /// Some Testcontainers implementations use this label instead of, or in
+    /// addition to, ``labelReaper``.
+    public static let labelRyuk = labelBase + ".ryuk"
+
+    /// Label key indicating a resource should be reaped by the resource reaper.
+    ///
+    /// When Ryuk is enabled, containers and networks tagged with this label
+    /// (value `"true"`) will be automatically cleaned up after the session
+    /// ends. Currently a no-op in testcontainers-swift because the resource
+    /// reaper is not yet implemented.
+    public static let labelReap = labelBase + ".reap"
 
     // MARK: - Values
 

--- a/Sources/Testcontainers/Network.swift
+++ b/Sources/Testcontainers/Network.swift
@@ -110,7 +110,7 @@ public class NetworkBuilder {
     public func build() async throws -> DockerNetworkImpl {
         var mergedLabels = labels
         TestcontainersLabels.addDefaultLabels(to: &mergedLabels)
-        let networkId = try await client.createNetwork(name: name, driver: driver)
+        let networkId = try await client.createNetwork(name: name, driver: driver, labels: mergedLabels)
         return DockerNetworkImpl(id: networkId, name: name, driver: driver, client: client)
     }
 }

--- a/Sources/Testcontainers/Network.swift
+++ b/Sources/Testcontainers/Network.swift
@@ -54,6 +54,7 @@ public class NetworkBuilder {
     private let name: String
     private var driver: String = "bridge"
     private var Internal: Bool = false
+    private var labels: [String: String] = [:]
     private let client: DockerClient
 
     /// Initializes a new network builder.
@@ -81,10 +82,34 @@ public class NetworkBuilder {
         return self
     }
 
+    /// Sets a single label on the network.
+    /// - Parameters:
+    ///   - key: The label key.
+    ///   - value: The label value.
+    /// - Returns: The builder instance for chaining.
+    @discardableResult
+    public func withLabel(_ key: String, _ value: String) -> NetworkBuilder {
+        labels[key] = value
+        return self
+    }
+
+    /// Sets multiple labels on the network from a dictionary.
+    /// - Parameter labels: A dictionary of labels.
+    /// - Returns: The builder instance for chaining.
+    @discardableResult
+    public func withLabel(_ labels: [String: String]) -> NetworkBuilder {
+        self.labels.merge(labels) { _, new in new }
+        return self
+    }
+
     /// Builds and creates the network.
+    ///
+    /// Standard Testcontainers labels are automatically applied to the network.
     /// - Returns: A Docker network instance.
     /// - Throws: An error if network creation fails.
     public func build() async throws -> DockerNetworkImpl {
+        var mergedLabels = labels
+        TestcontainersLabels.addDefaultLabels(to: &mergedLabels)
         let networkId = try await client.createNetwork(name: name, driver: driver)
         return DockerNetworkImpl(id: networkId, name: name, driver: driver, client: client)
     }

--- a/Sources/Testcontainers/RawEndpoints.swift
+++ b/Sources/Testcontainers/RawEndpoints.swift
@@ -89,8 +89,8 @@ struct RawCreateNetworkEndpoint: Endpoint {
     var method: HTTPMethod = .POST
     var body: CreateNetworkBody?
 
-    init(name: String, driver: String) {
-        self.body = CreateNetworkBody(Name: name, Driver: driver)
+    init(name: String, driver: String, labels: [String: String] = [:]) {
+        self.body = CreateNetworkBody(Name: name, Driver: driver, Labels: labels.isEmpty ? nil : labels)
     }
 
     var path: String {
@@ -100,6 +100,7 @@ struct RawCreateNetworkEndpoint: Endpoint {
     struct CreateNetworkBody: Codable {
         let Name: String
         let Driver: String
+        let Labels: [String: String]?
     }
 
     struct CreateNetworkResponse: Codable {

--- a/Sources/Testcontainers/Version.swift
+++ b/Sources/Testcontainers/Version.swift
@@ -1,0 +1,8 @@
+/// Single source of truth for the **testcontainers-swift** library version.
+///
+/// All version references (labels, HTTP headers, User-Agent) read from here.
+/// When cutting a new release, update ``current`` and tag the commit.
+public enum PackageVersion {
+    /// The current semantic version of testcontainers-swift.
+    public static let current = "0.1.0"
+}

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -1,6 +1,6 @@
 @testable import DockerClientSwift
 import NIOHTTP1
-import Testcontainers
+@testable import Testcontainers
 import XCTest
 
 final class ContainerTests: XCTestCase {

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -740,6 +740,18 @@ final class TestcontainersLabelsTests: XCTestCase {
         XCTAssertEqual(TestcontainersLabels.labelSessionId, "org.testcontainers.sessionId")
     }
 
+    func testLabelReaperValue() {
+        XCTAssertEqual(TestcontainersLabels.labelReaper, "org.testcontainers.reaper")
+    }
+
+    func testLabelRyukValue() {
+        XCTAssertEqual(TestcontainersLabels.labelRyuk, "org.testcontainers.ryuk")
+    }
+
+    func testLabelReapValue() {
+        XCTAssertEqual(TestcontainersLabels.labelReap, "org.testcontainers.reap")
+    }
+
     func testLangIsSwift() {
         XCTAssertEqual(TestcontainersLabels.lang, "swift")
     }

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -665,7 +665,6 @@ final class ContainerBuilderConfigurationTests: XCTestCase {
         XCTAssertEqual(container.labels["app"], "web")
         XCTAssertEqual(container.labels["env"], "test")
         XCTAssertEqual(container.labels["tier"], "frontend")
-        
     }
 
     func testBuilderWithSpecificPortBinding() {

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -716,3 +716,150 @@ final class ContainerBuilderConfigurationTests: XCTestCase {
         XCTAssertEqual(container.labels["env"], "test")
     }
 }
+
+// MARK: - Testcontainers Labels Tests
+
+final class TestcontainersLabelsTests: XCTestCase {
+
+    // MARK: - Label Constants
+
+    func testLabelBaseValue() {
+        XCTAssertEqual(TestcontainersLabels.labelBase, "org.testcontainers")
+    }
+
+    func testLabelLangValue() {
+        XCTAssertEqual(TestcontainersLabels.labelLang, "org.testcontainers.lang")
+    }
+
+    func testLabelVersionValue() {
+        XCTAssertEqual(TestcontainersLabels.labelVersion, "org.testcontainers.version")
+    }
+
+    func testLabelSessionIdValue() {
+        XCTAssertEqual(TestcontainersLabels.labelSessionId, "org.testcontainers.sessionId")
+    }
+
+    func testLangIsSwift() {
+        XCTAssertEqual(TestcontainersLabels.lang, "swift")
+    }
+
+    func testVersionIsNotEmpty() {
+        XCTAssertFalse(TestcontainersLabels.version.isEmpty)
+    }
+
+    // MARK: - Session ID
+
+    func testSessionIdIsNonEmpty() {
+        XCTAssertFalse(TestcontainersLabels.sessionId.isEmpty)
+    }
+
+    func testSessionIdIsValidUUID() {
+        // Session ID should be a valid UUID string
+        XCTAssertNotNil(UUID(uuidString: TestcontainersLabels.sessionId))
+    }
+
+    func testSessionIdIsStableAcrossCalls() {
+        let firstCall = TestcontainersLabels.sessionId
+        let secondCall = TestcontainersLabels.sessionId
+        XCTAssertEqual(firstCall, secondCall, "Session ID should be stable within the same process")
+    }
+
+    // MARK: - Default Labels
+
+    func testDefaultLabelsContainsAllFourKeys() {
+        let labels = TestcontainersLabels.defaultLabels
+        XCTAssertEqual(labels.count, 4)
+        XCTAssertNotNil(labels[TestcontainersLabels.labelBase])
+        XCTAssertNotNil(labels[TestcontainersLabels.labelLang])
+        XCTAssertNotNil(labels[TestcontainersLabels.labelVersion])
+        XCTAssertNotNil(labels[TestcontainersLabels.labelSessionId])
+    }
+
+    func testDefaultLabelsValues() {
+        let labels = TestcontainersLabels.defaultLabels
+        XCTAssertEqual(labels[TestcontainersLabels.labelBase], "true")
+        XCTAssertEqual(labels[TestcontainersLabels.labelLang], "swift")
+        XCTAssertEqual(labels[TestcontainersLabels.labelVersion], TestcontainersLabels.version)
+        XCTAssertEqual(labels[TestcontainersLabels.labelSessionId], TestcontainersLabels.sessionId)
+    }
+
+    // MARK: - addDefaultLabels
+
+    func testAddDefaultLabelsToEmptyDictionary() {
+        var labels: [String: String] = [:]
+        TestcontainersLabels.addDefaultLabels(to: &labels)
+        XCTAssertEqual(labels.count, 4)
+        XCTAssertEqual(labels["org.testcontainers"], "true")
+        XCTAssertEqual(labels["org.testcontainers.lang"], "swift")
+    }
+
+    func testAddDefaultLabelsPreservesUserLabels() {
+        var labels: [String: String] = ["app": "myapp", "env": "test"]
+        TestcontainersLabels.addDefaultLabels(to: &labels)
+        XCTAssertEqual(labels["app"], "myapp")
+        XCTAssertEqual(labels["env"], "test")
+        XCTAssertEqual(labels["org.testcontainers"], "true")
+        XCTAssertEqual(labels.count, 6) // 2 user + 4 standard
+    }
+
+    func testAddDefaultLabelsDoesNotOverwriteUserLabels() {
+        var labels: [String: String] = [
+            "org.testcontainers": "custom",
+            "org.testcontainers.lang": "custom-lang",
+        ]
+        TestcontainersLabels.addDefaultLabels(to: &labels)
+        XCTAssertEqual(labels["org.testcontainers"], "custom",
+                       "User-defined label should not be overwritten")
+        XCTAssertEqual(labels["org.testcontainers.lang"], "custom-lang",
+                       "User-defined label should not be overwritten")
+        // But the missing keys should still be added
+        XCTAssertNotNil(labels["org.testcontainers.version"])
+        XCTAssertNotNil(labels["org.testcontainers.sessionId"])
+    }
+
+    // MARK: - ContainerBuilder Integration
+
+    func testBuilderBuildIncludesStandardLabels() {
+        let container = ContainerBuilder("alpine:latest").build()
+
+        XCTAssertEqual(container.labels["org.testcontainers"], "true")
+        XCTAssertEqual(container.labels["org.testcontainers.lang"], "swift")
+        XCTAssertEqual(container.labels["org.testcontainers.version"], TestcontainersLabels.version)
+        XCTAssertEqual(container.labels["org.testcontainers.sessionId"], TestcontainersLabels.sessionId)
+    }
+
+    func testBuilderBuildWithUserLabelsIncludesBoth() {
+        let container = ContainerBuilder("alpine:latest")
+            .withLabel("app", "myapp")
+            .withLabel("env", "test")
+            .build()
+
+        // User labels present
+        XCTAssertEqual(container.labels["app"], "myapp")
+        XCTAssertEqual(container.labels["env"], "test")
+
+        // Standard labels present
+        XCTAssertEqual(container.labels["org.testcontainers"], "true")
+        XCTAssertEqual(container.labels["org.testcontainers.lang"], "swift")
+    }
+
+    func testBuilderBuildUserLabelsNotOverwritten() {
+        let container = ContainerBuilder("alpine:latest")
+            .withLabel("org.testcontainers", "custom-value")
+            .build()
+
+        XCTAssertEqual(container.labels["org.testcontainers"], "custom-value",
+                       "User-defined standard label should not be overwritten by defaults")
+    }
+
+    func testAllContainersShareSameSessionId() {
+        let container1 = ContainerBuilder("alpine:latest").build()
+        let container2 = ContainerBuilder("nginx:latest").build()
+
+        XCTAssertEqual(
+            container1.labels["org.testcontainers.sessionId"],
+            container2.labels["org.testcontainers.sessionId"],
+            "All containers in the same process should have the same session ID"
+        )
+    }
+}

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -1,3 +1,5 @@
+@testable import DockerClientSwift
+import NIOHTTP1
 import Testcontainers
 import XCTest
 
@@ -720,7 +722,6 @@ final class ContainerBuilderConfigurationTests: XCTestCase {
 // MARK: - Testcontainers Labels Tests
 
 final class TestcontainersLabelsTests: XCTestCase {
-
     // MARK: - Label Constants
 
     func testLabelBaseValue() {
@@ -861,5 +862,87 @@ final class TestcontainersLabelsTests: XCTestCase {
             container2.labels["org.testcontainers.sessionId"],
             "All containers in the same process should have the same session ID"
         )
+    }
+}
+
+// MARK: - Testcontainers HTTP Headers Tests
+
+final class TestcontainersHeadersTests: XCTestCase {
+    // MARK: - testcontainersHeaders()
+
+    func testHeadersContainSessionId() {
+        let headers = TestcontainersDockerClient.testcontainersHeaders()
+        let sid = headers["x-tc-sid"].first
+        XCTAssertNotNil(sid, "x-tc-sid header must be present")
+        XCTAssertEqual(sid, TestcontainersLabels.sessionId)
+    }
+
+    func testHeadersSessionIdIsValidUUID() throws {
+        let headers = TestcontainersDockerClient.testcontainersHeaders()
+        let sid = try XCTUnwrap(headers["x-tc-sid"].first)
+        XCTAssertNotNil(UUID(uuidString: sid), "x-tc-sid header must be a valid UUID")
+    }
+
+    func testHeadersContainUserAgent() throws {
+        let headers = TestcontainersDockerClient.testcontainersHeaders()
+        let ua = headers["User-Agent"].first
+        XCTAssertNotNil(ua, "User-Agent header must be present")
+        XCTAssertTrue(try XCTUnwrap(ua?.hasPrefix("tc-swift/")),
+                      "User-Agent should start with tc-swift/")
+    }
+
+    func testHeadersUserAgentIncludesVersion() throws {
+        let headers = TestcontainersDockerClient.testcontainersHeaders()
+        let ua = try XCTUnwrap(headers["User-Agent"].first)
+        XCTAssertEqual(ua, "tc-swift/\(TestcontainersLabels.version)")
+    }
+
+    func testHeadersAreStableAcrossCalls() {
+        let h1 = TestcontainersDockerClient.testcontainersHeaders()
+        let h2 = TestcontainersDockerClient.testcontainersHeaders()
+        XCTAssertEqual(h1["x-tc-sid"].first, h2["x-tc-sid"].first,
+                       "Session ID header should be stable")
+        XCTAssertEqual(h1["User-Agent"].first, h2["User-Agent"].first,
+                       "User-Agent header should be stable")
+    }
+
+    // MARK: - DockerClient.buildHeaders() with custom headers
+
+    func testBuildHeadersIncludesBaseHeaders() {
+        let client = DockerClientSwift.DockerClient(daemonSocket: "/dev/null")
+        let headers = client.buildHeaders()
+        XCTAssertEqual(headers["Content-Type"].first, "application/json")
+        XCTAssertEqual(headers["Host"].first, "localhost")
+    }
+
+    func testBuildHeadersWithCustomHeaders() {
+        let custom = HTTPHeaders([
+            ("x-tc-sid", "test-session-id"),
+            ("User-Agent", "tc-swift/0.1.0"),
+        ])
+        let client = DockerClientSwift.DockerClient(
+            daemonSocket: "/dev/null",
+            customHeaders: custom
+        )
+        let headers = client.buildHeaders()
+
+        // Custom headers present
+        XCTAssertEqual(headers["x-tc-sid"].first, "test-session-id")
+        XCTAssertEqual(headers["User-Agent"].first, "tc-swift/0.1.0")
+
+        // Base headers still present
+        XCTAssertEqual(headers["Content-Type"].first, "application/json")
+        XCTAssertEqual(headers["Host"].first, "localhost")
+    }
+
+    func testBuildHeadersWithNoCustomHeaders() {
+        let client = DockerClientSwift.DockerClient(
+            daemonSocket: "/dev/null",
+            customHeaders: HTTPHeaders()
+        )
+        let headers = client.buildHeaders()
+        XCTAssertEqual(headers["Content-Type"].first, "application/json")
+        XCTAssertEqual(headers["Host"].first, "localhost")
+        XCTAssertNil(headers["x-tc-sid"].first)
     }
 }

--- a/Tests/TestcontainersTests.swift
+++ b/Tests/TestcontainersTests.swift
@@ -661,10 +661,11 @@ final class ContainerBuilderConfigurationTests: XCTestCase {
             .withLabel(["app": "web", "env": "test", "tier": "frontend"])
 
         let container = builder.build()
-        XCTAssertEqual(container.labels.count, 3)
+        XCTAssertGreaterThanOrEqual(container.labels.count, 3)
         XCTAssertEqual(container.labels["app"], "web")
         XCTAssertEqual(container.labels["env"], "test")
         XCTAssertEqual(container.labels["tier"], "frontend")
+        
     }
 
     func testBuilderWithSpecificPortBinding() {


### PR DESCRIPTION

## Summary by Sourcery

Introduce standard Testcontainers labels and HTTP headers, and propagate them through container, network, and Docker client integrations.

New Features:
- Add TestcontainersLabels utility providing standard label keys, values, and helpers for default label application.
- Automatically apply standard Testcontainers labels to containers and networks created via ContainerBuilder and NetworkBuilder.
- Allow DockerClientSwift.DockerClient to accept and merge custom HTTP headers into all Docker API requests.
- Have TestcontainersDockerClient send Testcontainers-specific headers (session ID and User-Agent) on every Docker API call.

Enhancements:
- Extend NetworkBuilder and ContainerBuilder to support user-defined labels while preserving them when merging standard labels.
- Add a header-building helper in DockerClientSwift.DockerClient to centralize header composition and reuse.

Build:
- Update package dependencies to include NIOHTTP1 for header handling in sources and tests.

Tests:
- Add comprehensive tests for Testcontainers label constants, default label behavior, and their integration with ContainerBuilder.
- Add tests covering TestcontainersDockerClient HTTP headers and DockerClientSwift.DockerClient header merging behavior.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/dragosv/testcontainers-swift/31?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->